### PR TITLE
Customize message/payload before sending to server

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+language: node_js
+node_js: "7"
+
+cache:
+  directories:
+    - "node_modules"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # channels-api-client
 
+[![Build Status](https://travis-ci.org/usstudentloancenter/channels-api-client.svg?branch=master)](https://travis-ci.org/usstudentloancenter/channels-api-client)
+
 This package aims to provide a **simple**, **reliable**, and **generic** interface to consume [channels-api](https://github.com/linuxlewis/channels-api) powered WebSocket APIs.
 
 

--- a/README.md
+++ b/README.md
@@ -71,12 +71,12 @@ client.request('mystream', {key: 'value'}).then(response => {
 
 ## Configuration
 
-Some customization of ChannelsApi is available. Pass an object as the second argument to `channelsApi.connect()` with the following properties:
+The client can be customized by passing an object as the second argument to `connect()` or `createClient()`. The available options are described below.
 
 ```javascript
-const client = channelsApi.connecgt('wss://example.com', {
+const client = channelsApi.connect('wss://example.com', {
   preprocessPayload: (stream, payload, requestId) => {
-    // Modify payload any way you see fit, before its sent over the wire
+    // Modify payload any way you see fit, before it's sent over the wire
     // For instance, add a custom authentication token:
     payload.token = '123';
     // Be sure not to return anything if you modify payload

--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ npm install --save @usslc/channels-api
 ## Usage
 
 ```javascript
-const channels_api = require('channels-api');
-const client = channels_api.connect('wss://example.com');
+const channelsApi = require('channels-api');
+const client = channelsApi.connect('wss://example.com');
 
 client.create('people', {name: 'Alex'}).then(person => {
   console.info('Created:', person);
@@ -65,5 +65,48 @@ personalSubscription.cancel();
 // Make a generic request to a multiplexer stream
 client.request('mystream', {key: 'value'}).then(response => {
   console.info('Got mystream response, yo:', response);
+});
+```
+
+
+## Configuration
+
+Some customization of ChannelsApi is available. Pass an object as the second argument to `channelsApi.connect()` with the following properties:
+
+```javascript
+const client = channelsApi.connecgt('wss://example.com', {
+  preprocessPayload: (stream, payload, requestId) => {
+    // Modify payload any way you see fit, before its sent over the wire
+    // For instance, add a custom authentication token:
+    payload.token = '123';
+    // Be sure not to return anything if you modify payload
+
+    // Or, you can overwrite the payload by returning a new object:
+    return {'this': 'is my new payload'};
+  },
+
+  preprocessMessage: (message) => {
+    // The "message" is the final value which will be serialized and sent over the wire.
+    // It includes the stream and the payload.
+
+    // Modify the message any way you see fit, before its sent over the wire.
+    message.token = 'abc';
+    // Don't return anything if you modify message
+
+    // Or, you can overwrite the the message by returning a new object:
+    return {stream: 'creek', payload: 'craycrayload'};
+  },
+
+  // Options to be passed to ReconnectingWebsocket
+  // See https://github.com/pladaria/reconnecting-websocket#configure for more info
+  websocket: {
+    constructor: isGlobalWebSocket() ? WebSocket : null,
+    maxReconnectionDelay: 10000,
+    minReconnectionDelay: 1500,
+    reconnectionDelayGrowFactor: 1.3,
+    connectionTimeout: 4000,
+    maxRetries: Infinity,
+    debug: false,
+  }
 });
 ```

--- a/src/interface.js.flow
+++ b/src/interface.js.flow
@@ -250,11 +250,53 @@ interface IStreamingAPI {
    *
    * @param stream Name of object's type stream
    * @param payload Data to send as payload
-   * @param requestId An optional custom requestId may be passed to the server.
-   *                  If not specified, one will be generated.
+   * @param requestId Value to send as request_id to the server. If not
+   *                  specified, one will be generated.
    * @return Promise resolves/rejects when response received.
    *         On success, the promise will be resolved with response.data.
    *         On failure, the promise will be rejected with the entire API response.
    */
   request(stream: string, payload: Object, requestId?: string): Promise<Object>;
 }
+
+
+/**
+ * Callback which may mutate the payload before being sent to the server. A new
+ * object may be returned, which will be sent instead.
+ *
+ * @param stream Name of object's type stream
+ * @param payload Data which will be sent as payload. This may be mutated, as
+ *                long as no value is then returned from the callback.
+ * @param requestId Value in the payload sent as request_id to the server.
+ * @return undefined to send the same payload object as passed in; or a new
+ *         Object to be sent instead.
+ *
+ */
+export type PayloadPreprocessor = (stream: string, payload: Object, requestId: string) => ?Object;
+
+
+/**
+ * Callback which may mutate the multiplexed message (which includes the stream
+ * and payload) before being sent over the wire.
+ *
+ * @param message The message to be sent over the wire to the server.
+ * @return undefined to send the same message object as passed in (and
+ *         potentially mutated); or an Object to be sent instead.
+ */
+export type MessagePreprocessor = (message: Object) => ?Object;
+
+
+export type ChannelsApiOptions = {
+  preprocessPayload: PayloadPreprocessor,
+  preprocessMessage: MessagePreprocessor,
+
+  // ReconnectingWebsocket options
+  websocket: {
+    maxReconnectionDelay?: number;
+    minReconnectionDelay?: number;
+    reconnectionDelayGrowFactor?: number;
+    connectionTimeout?: number;
+    maxRetries?: number;
+    debug?: boolean;
+  }
+};


### PR DESCRIPTION
Two new options may be passed to preprocess the message (final value before serializing and sending to server) and/or the payload (just the data, without the stream inserted) before sending to the server. Check the README changes for full info.

Note: this introduces a backwards incompatible change to the public API, and will bump the major version.